### PR TITLE
fix: remove encryption/decryption of transaction IDs

### DIFF
--- a/Controller/Checkout/Commit.php
+++ b/Controller/Checkout/Commit.php
@@ -122,7 +122,7 @@ class Commit extends Action
 
             // Decrypt the transaction ID
             try {
-                $transactionId = $this->encryptor->decrypt($encryptedTransactionId);
+                $transactionId = $encryptedTransactionId;
             } catch (Exception $e) {
                 $this->logger->error('Commit: Error decrypting transaction ID: ' . $e->getMessage(), ['exception' => $e]);
                 throw new LocalizedException(__('Invalid transaction ID'));

--- a/Controller/Checkout/Create.php
+++ b/Controller/Checkout/Create.php
@@ -152,7 +152,7 @@ class Create extends Action
             );
 
             // Encrypt the transaction ID for URLs
-            $encryptedTransactionId = $this->encryptor->encrypt($transactionId);
+            $encryptedTransactionId = $transactionId;
 
             // Prepare request data with updated URLs
             $requestData = [

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fintoc/magento2-payment",
     "description": "Fintoc Payment integration for Adobe Commerce",
     "type": "magento2-module",
-    "version": "1.0.5",
+    "version": "1.0.6",
     "license": "GPL-3.0",
     "require": {
         "php": "^7.4||^8.0||^8.1||^8.2||^8.3",


### PR DESCRIPTION
- Updated `Commit.php` and `Create.php` to use plain transaction IDs, removing encryption and decryption logic.
- Bumped module version to 1.0.6 in `composer.json`.