### PR TITLE
fix: corregir ID de pago enviado en refunds

### DIFF
--- a/Service/Webhook/Handler/PaymentIntentSucceededHandler.php
+++ b/Service/Webhook/Handler/PaymentIntentSucceededHandler.php
@@ -130,9 +130,22 @@ class PaymentIntentSucceededHandler extends AbstractPaymentIntentHandler
         if ($order->getState() === Order::STATE_PROCESSING) {
             $tx = $this->getFirstTransactionByOrder($orderId);
             if ($tx) {
+                $this->transactionService->updateTransactionStatus($tx, TransactionInterface::STATUS_SUCCESS, [
+                    'updated_by' => 'webhook',
+                    'error_message' => null,
+                ]);
                 $this->appendWebhookPayload($tx, $event, WebhookConstants::EV_PI_SUCCEEDED);
             }
-            $this->logger->debug('Order already processed: ' . $orderId);
+            // Ensure payment intent ID is stored even if order was already processed
+            // (e.g. invoice created before webhook arrived). Without this, refunds
+            // fall back to the internal transaction ID instead of the real pi_xxx ID.
+            $extra = [];
+            if (isset($pi['senderAccount'])) {
+                $extra['fintoc_sender_account'] = $this->json->serialize($pi['senderAccount']);
+            }
+            $this->setPiPaymentInfo($order, $pi, $extra);
+            $order->save();
+            $this->logger->debug('Order already processed, payment info updated: ' . $orderId);
             return;
         }
 


### PR DESCRIPTION
## Contexto

Al procesar un refund, el plugin enviaba el ID interno de Magento (`fintoc_69a708b3...`) en vez del hashid real de Fintoc (`pi_xxx`) a `POST /v1/refunds`, provocando el rechazo de la API.

## Causa raíz

En `PaymentIntentSucceededHandler`, cuando el webhook `payment_intent.succeeded` llega y la orden ya está en estado `PROCESSING`, el handler hacía un early return **sin llamar a `setPiPaymentInfo()`**. Esto ocurre cuando la factura se crea antes de que llegue el webhook (o si el webhook se procesa dos veces).

Al no guardarse `fintoc_payment_id` con el valor real (`pi_xxx`), el `RefundService::getPaymentIntentIdForOrder()` caía en su fallback que retornaba el `transaction_id` interno de la transacción pre-autorización (`fintoc_69a708b3...`).

## Solución

En la rama de early return (orden ya en `PROCESSING`) del `PaymentIntentSucceededHandler`:

1. **Se agrega `setPiPaymentInfo()`** para almacenar el ID real del payment intent (`pi_xxx`) en `fintoc_payment_id`
2. **Se agrega `updateTransactionStatus()`** para marcar la transacción como `SUCCESS` (antes quedaba en su estado previo)
3. **Se agrega `$order->save()`** para persistir los cambios (consistente con las demás ramas del handler)

## Archivos modificados

- `Service/Webhook/Handler/PaymentIntentSucceededHandler.php`

## Plan de pruebas

- [ ] Simular webhook `payment_intent.succeeded` cuando la orden ya está en `PROCESSING`
- [ ] Verificar que `fintoc_payment_id` se almacena con formato `pi_xxx`
- [ ] Ejecutar refund y confirmar que la API de Fintoc recibe el ID correcto
- [ ] Verificar que el flujo normal (orden en `NEW`) sigue funcionando correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)