### PR TITLE
fix: restaurar carrito al volver del redirect sin completar pago

### DIFF
--- a/Plugin/RestoreQuoteOnCartLoad.php
+++ b/Plugin/RestoreQuoteOnCartLoad.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace Fintoc\Payment\Plugin;
+
+use Fintoc\Payment\Api\LoggerServiceInterface as LoggerInterface;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Sales\Model\Order;
+
+/**
+ * Restores the shopping cart when a customer returns to the store
+ * without completing a Fintoc payment (e.g. browser back button).
+ *
+ * Magento consumes the quote when the order is placed, so if the
+ * customer never reaches Fintoc's cancel_url the cart appears empty.
+ * This plugin detects that situation and restores the quote.
+ */
+class RestoreQuoteOnCartLoad
+{
+    /** @var CheckoutSession */
+    private $checkoutSession;
+
+    /** @var LoggerInterface */
+    private $logger;
+
+    public function __construct(
+        CheckoutSession $checkoutSession,
+        LoggerInterface $logger
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Before the checkout cart page is rendered, check whether the last
+     * order is a pending Fintoc payment whose quote should be restored.
+     *
+     * @param \Magento\Checkout\Controller\Cart\Index $subject
+     */
+    public function beforeExecute(\Magento\Checkout\Controller\Cart\Index $subject): void
+    {
+        try {
+            $order = $this->checkoutSession->getLastRealOrder();
+            if (!$order || !$order->getId()) {
+                return;
+            }
+
+            $payment = $order->getPayment();
+            if (!$payment || $payment->getMethod() !== 'fintoc_payment') {
+                return;
+            }
+
+            // Only restore if the order is still in a non-terminal pending state
+            $state = $order->getState();
+            if (!in_array($state, [Order::STATE_NEW, Order::STATE_PENDING_PAYMENT], true)) {
+                return;
+            }
+
+            // Skip if the Commit controller already marked this payment as successful
+            // (covers the race window before the webhook transitions order to PROCESSING)
+            $txStatus = $payment->getAdditionalInformation('fintoc_transaction_status');
+            if ($txStatus === 'success') {
+                return;
+            }
+
+            // Check that the quote hasn't already been restored / a new quote started
+            $quote = $this->checkoutSession->getQuote();
+            if ($quote && $quote->getId() && $quote->getItemsCount() > 0) {
+                return;
+            }
+
+            $this->checkoutSession->restoreQuote();
+            $this->logger->info('RestoreQuoteOnCartLoad: restored quote for pending Fintoc order ' . $order->getIncrementId());
+        } catch (\Exception $e) {
+            $this->logger->warning('RestoreQuoteOnCartLoad: ' . get_class($e) . ': ' . $e->getMessage());
+        }
+    }
+}

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!-- Copyright © Fintoc. -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+    <!-- Restore cart when customer returns from Fintoc without completing payment -->
+    <type name="Magento\Checkout\Controller\Cart\Index">
+        <plugin name="fintoc_restore_quote_on_cart_load"
+                type="Fintoc\Payment\Plugin\RestoreQuoteOnCartLoad"
+                sortOrder="10" />
+    </type>
+</config>


### PR DESCRIPTION
## Contexto

Cuando el cliente vuelve al store sin completar el pago en Fintoc (usando el botón atrás del navegador, cerrando la pestaña, etc.), el carrito aparece vacío. Esto ocurre porque Magento consume el quote al crear la orden antes del redirect.

## Causa raíz

El flujo actual es:
1. `placeOrderAction()` en el JS crea la orden → **consume el quote** (carrito)
2. Se llama a `/fintoc/checkout/create` → redirige al usuario a Fintoc
3. Si el usuario usa el botón atrás del navegador, **nunca pasa por el `Commit` controller**
4. El `Commit` controller (acción cancel) ya tiene `restoreQuote()`, pero solo se ejecuta cuando Fintoc redirige a la `cancel_url`

## Solución

Se agrega un **plugin (before-interceptor)** en `Magento\Checkout\Controller\Cart\Index` que detecta la situación y restaura el quote automáticamente.

El plugin verifica las siguientes condiciones antes de restaurar:

| Condición | Acción |
|---|---|
| No hay orden reciente o no es Fintoc | No hace nada |
| Orden en estado terminal (`PROCESSING`, `CANCELED`, etc.) | No hace nada |
| Pago ya marcado como exitoso (`fintoc_transaction_status = success`) | No hace nada |
| Carrito ya tiene productos | No hace nada |
| Orden Fintoc pendiente + carrito vacío | **Restaura el quote** |

## Archivos agregados

- `Plugin/RestoreQuoteOnCartLoad.php` — Plugin con la lógica de restauración
- `etc/frontend/di.xml` — Registro del plugin (scope frontend)

## Plan de pruebas

- [ ] Iniciar pago con Fintoc, usar botón atrás del navegador → carrito debe restaurarse
- [ ] Completar pago exitosamente → carrito NO debe restaurarse al visitar `/checkout/cart`
- [ ] Cancelar pago vía botón de Fintoc (cancel_url) → carrito debe restaurarse (flujo existente, sin regresión)
- [ ] Visitar carrito sin orden Fintoc pendiente → sin efecto
- [ ] Requiere `bin/magento setup:upgrade` + `bin/magento cache:flush` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)